### PR TITLE
Update of IT & EN languages for Top Ten Topics extension

### DIFF
--- a/language/en/common.php
+++ b/language/en/common.php
@@ -1,12 +1,42 @@
 <?php
+/**
+*
+* Top Ten Topics extension for the phpBB Forum Software package.
+*
+* @copyright (c) 2015 brunino <http://www.brunino.altervista.org>
+* @license GNU General Public License, version 2 (GPL-2.0)
+*
+*/
+
+/**
+* DO NOT CHANGE
+*/
 if (!defined('IN_PHPBB'))
 {
 	exit;
 }
+
 if (empty($lang) || !is_array($lang))
 {
 	$lang = array();
 }
+
+// DEVELOPERS PLEASE NOTE
+//
+// All language files should use UTF-8 as their encoding and the files must not contain a BOM.
+//
+// Placeholders can now contain order information, e.g. instead of
+// 'Page %s of %s' you can (and should) write 'Page %1$s of %2$s', this allows
+// translators to re-order the output of data while ensuring it remains correct
+//
+// You do not need this where single placeholders are used, e.g. 'Message %d' is fine
+// equally where a string contains only two placeholders which are used to wrap text
+// in a url you again do not need to specify an order e.g., 'Click %sHERE%s' is fine
+//
+// Some characters you may want to copy&paste:
+// ’ « » “ ” …
+//
+
 $lang = array_merge($lang, array(
 	'LAST_TOPICS'			=> 'Last Topics',
 	'LAST_POSTS'			=> 'Last Posts',
@@ -14,20 +44,20 @@ $lang = array_merge($lang, array(
 	'ACP_TTT_TITLE'			=> 'General Settings',
 	'ACP_TTT_CATEGORY'		=> 'Top Ten Topics',
 	'ACP_POSITION'		=> 'Position of extension box',
-	'ACP_POSITION_DESC'	=> 'Note! If you want to use the position "After forums list but before login box", you must have a style updated to phpBB 3.1.1',
+	'ACP_POSITION_DESC'	=> 'Note ! If you want to use the position “After forums list but before login box”, you must have a style updated to phpBB 3.1.1.',
 	'ACP_GUEST'		=> 'Show box to guests',
 	'ACP_NUMBER'		=> 'Number of extracted topics/posts',
-	'ACP_NUMBER_DESC'	=> 'If you enter a number of topics higher than an user can view, the page will generate an error',
+	'ACP_NUMBER_DESC'	=> 'If you enter a number of topics higher than an user can view, the page will generate an error.',
 	'ACP_DATA'		=> 'Default time of top topics',
 	'ACP_IMPORTANT'		=> 'Choose which types of topic to display',
 	'ACP_FORUM'		=> 'Choose which types of forum to display',
-	'ACP_FORUM_DESC'	=> 'You must enter the forums ID to exclude, only separated by commas without spaces, for example 1,2,3 <br>If you do not want to exclude any forum leave this field empty. The extension do not show the topics to users where they do not have the necessary permissions..',
-	'BEFORE_FORUMLIST'		=> 'Before forums list and before link "mark forum read"',
+	'ACP_FORUM_DESC'	=> 'You must enter the forums ID to exclude, only separated by commas without spaces, for example 1,2,3.<br>If you do not want to exclude any forum leave this field empty. The extension do not show the topics to users where they do not have the necessary permissions.',
+	'BEFORE_FORUMLIST'		=> 'Before forums list and before link “mark forum read”',
 	'AFTER_FORUMLIST'		=> 'After forums list and after login box',
-	'AFTER_MARKFORUM'		=> 'Before forum list but after link "mark forum read"',
+	'AFTER_MARKFORUM'		=> 'Before forum list but after link “mark forum read”',
 	'BEFORE_LOGIN' 			=> 'After forum list but before login box',
 	'ALL_FOOTER'			=> 'On footer of all pages of forum',
-	'ACP_TTT_SAVED'			=> 'Settings of Top Ten Topics have been updated',
+	'ACP_TTT_SAVED'			=> 'Settings of Top Ten Topics have been updated.',
 	'SIXMONTH' => 'last 6 months',
 	'TWELVEMONTH' => 'last 12 months',
 	'ONEMONTH' => 'last month',
@@ -35,8 +65,7 @@ $lang = array_merge($lang, array(
 	'ALL_TOPICS' => 'All',
 	'TTT_BASED' => 'based on the <a href="http://giannidose.altervista.org">Micogian</a>&apos;s MOD',
 	'TNORMAL' => 'Only normal topic',
-	'TIMPORTANT' => 'Normal and important topics',
-	'TANNUNCE' => 'Normal, important and sticky topics',
-	'TGLOBAL' => 'Normal, important, sticky and global sticky topics',
-	'TTT_BY' => 'by',
+	'TIMPORTANT' => 'Normal and sticky topics',
+	'TANNUNCE' => 'Normal, sticky and announcement topics',
+	'TGLOBAL' => 'Normal, sticky, announcement and global announcement topics',
 ));

--- a/language/it/common.php
+++ b/language/it/common.php
@@ -1,11 +1,16 @@
 <?php
-/** 
-* 
-* @package StaffIt - Top Ten Topics 
-* @copyright (c) 2014 brunino
-* @license http://opensource.org/licenses/gpl-2.0.php GNU General Public License v2 
-* 
-*/ 
+/**
+*
+* Top Ten Topics extension for the phpBB Forum Software package.
+*
+* @copyright (c) 2015 brunino <http://www.brunino.altervista.org>
+* @license GNU General Public License, version 2 (GPL-2.0)
+*
+*/
+
+/**
+* DO NOT CHANGE
+*/
 if (!defined('IN_PHPBB'))
 {
 	exit;
@@ -16,27 +21,43 @@ if (empty($lang) || !is_array($lang))
 	$lang = array();
 }
 
+// DEVELOPERS PLEASE NOTE
+//
+// All language files should use UTF-8 as their encoding and the files must not contain a BOM.
+//
+// Placeholders can now contain order information, e.g. instead of
+// 'Page %s of %s' you can (and should) write 'Page %1$s of %2$s', this allows
+// translators to re-order the output of data while ensuring it remains correct
+//
+// You do not need this where single placeholders are used, e.g. 'Message %d' is fine
+// equally where a string contains only two placeholders which are used to wrap text
+// in a url you again do not need to specify an order e.g., 'Click %sHERE%s' is fine
+//
+// Some characters you may want to copy&paste:
+// ’ « » “ ” …
+//
+
 $lang = array_merge($lang, array(
 	'LAST_TOPICS'			=> 'Ultimi Topic',
     'LAST_POSTS'			=> 'Ultimi Post',
 	'TOP_TOPICS'			=> 'Argomenti più visti',
 	'ACP_TTT_TITLE'			=> 'Impostazioni generali',
 	'ACP_TTT_CATEGORY'		=> 'Top Ten Topics',
-	'ACP_POSITION'		=> 'Scegli la posizione del box nell\'indice',
-	'ACP_POSITION_DESC'	=> 'N.B. Per usare la posizione "Dopo la lista dei forum, ma prima del box di login" devi avere lo/gli stile/i in uso aggiornato/i almeno a phpBB 3.1.1',
+	'ACP_POSITION'		=> 'Scegli la posizione del box nell’indice',
+	'ACP_POSITION_DESC'	=> 'N.B. Per usare la posizione "Dopo la lista dei forum, ma prima del box di login" devi avere lo/gli stile/i in uso aggiornato/i almeno a phpBB 3.1.1.',
 	'ACP_GUEST'		=> 'Vuoi che sia mostrata agli utenti non registrati?',
 	'ACP_NUMBER'		=> 'Numero di topic e post estratti',
-	'ACP_NUMBER_DESC'	=> 'Se inserisci un numero di topic maggiore di quanti lutente può visualizzare, la pagina genererà un errore.',
+	'ACP_NUMBER_DESC'	=> 'Se inserisci un numero di topic maggiore di quanti lutente può visualizzare, la pagina genererà un errore.',
 	'ACP_DATA'		=> 'Periodo predefinito dei topic più visti',
 	'ACP_IMPORTANT'		=> 'Scegli quali tipi di topic visualizzare',
 	'ACP_FORUM'		=> 'Sezioni da escludere',
-	'ACP_FORUM_DESC'	=> 'Devi inserire gli ID delle sezioni da escludere, separati solo da virgole senza spazi: ad esempio 1,2,3<br>Se non vuoi escludere nessuna sezione lascia questo campo vuoto. Considera che lestensione non mostra agli utenti i topic postati nei forum a cui loro non hanno accesso.',
+	'ACP_FORUM_DESC'	=> 'Devi inserire gli ID delle sezioni da escludere, separati solo da virgole senza spazi: ad esempio 1,2,3.<br>Se non vuoi escludere nessuna sezione lascia questo campo vuoto. Considera che lestensione non mostra agli utenti i topic postati nei forum a cui loro non hanno accesso.',
 	'BEFORE_FORUMLIST'		=> 'Prima della lista dei forum e del link "segna come gi&agrave; letti"',
 	'AFTER_FORUMLIST'		=> 'Dopo la lista dei forum e del box di login',
 	'AFTER_MARKFORUM'		=> 'Prima della lista dei forum, ma dopo link "segna come gi&agrave; letti"',
 	'BEFORE_LOGIN' 			=> 'Dopo la lista dei forum, ma prima del box di login',
 	'ALL_FOOTER'			=> 'In tutte le pagine, nel footer',
-	'ACP_TTT_SAVED'			=> 'Impostazioni della Top Ten Topics aggiornate',
+	'ACP_TTT_SAVED'			=> 'Impostazioni della Top Ten Topics aggiornate.',
 	'SIXMONTH' => 'ultimi 6 mesi',
 	'TWELVEMONTH' => 'ultimi 12 mesi',
 	'ONEMONTH' => 'ultimo mese',
@@ -47,5 +68,4 @@ $lang = array_merge($lang, array(
 	'TIMPORTANT' => 'Topic normali e importanti',
 	'TANNUNCE' => 'Topic normali, importanti e annunci',
 	'TGLOBAL' => 'Topic normali, importanti, annunci e annunci globali',
-	'TTT_BY' => 'di',
 ));


### PR DESCRIPTION
Hi @bruninoit,

- Removes a language key replaced by a native common phpBB language key.
- Fixes typo.

Other PR related, here: https://github.com/bruninoit/toptentopics/pull/4.