### PR TITLE
Replace text & language key by two native phpBB language keys

### DIFF
--- a/styles/all/template/toptentopics_body.html
+++ b/styles/all/template/toptentopics_body.html
@@ -26,9 +26,9 @@
 		<!-- BEGIN topten_list -->
 			<li>
 				<dl>
-					<dd id="ttt_third" class="responsive-hide">&nbsp;<a style="font-weight: bold" href="{topten_list.LAST_TOPIC_LINK}" title="{topten_list.LAST_TOPIC_TITLE} (in: {topten_list.LAST_TOPIC_FORUM})">{topten_list.LAST_TOPIC_TITLE_SHORT}</a> <span style="color: #708090">({L_TTT_BY} {topten_list.LAST_TOPIC_AUTHOR})</span></dd>
-					<dd id="ttt_fourth" class="responsive-hide">{topten_list.VIEW_TOPIC_VIEWS} &nbsp;<a style="font-weight: bold" href="{topten_list.VIEW_TOPIC_LINK}" title="{topten_list.VIEW_TOPIC_TITLE} (in: {topten_list.VIEW_TOPIC_FORUM})">{topten_list.VIEW_TOPIC_TITLE_SHORT}</a> <span style="color: #708090">({L_TTT_BY} {topten_list.VIEW_TOPIC_AUTHOR})</span></dd>
-					<dd id="ttt_fifth" class="responsive-show"><a style=" font-weight: bold" href="{topten_list.LAST_POST_LINK}" title="{topten_list.LAST_POST_TITLE} (in: {topten_list.LAST_POST_FORUM})">{topten_list.LAST_POST_TITLE_SHORT}</a> <span style="color: #708090">({L_TTT_BY} {topten_list.LAST_POST_AUTHOR})</span></dd>               
+					<dd id="ttt_third" class="responsive-hide">&nbsp;<a style="font-weight: bold" href="{topten_list.LAST_TOPIC_LINK}" title="{topten_list.LAST_TOPIC_TITLE} ({L_IN}{L_COLON} {topten_list.LAST_TOPIC_FORUM})">{topten_list.LAST_TOPIC_TITLE_SHORT}</a> <span style="color: #708090">({L_POST_BY_AUTHOR} {topten_list.LAST_TOPIC_AUTHOR})</span></dd>
+					<dd id="ttt_fourth" class="responsive-hide">{topten_list.VIEW_TOPIC_VIEWS} &nbsp;<a style="font-weight: bold" href="{topten_list.VIEW_TOPIC_LINK}" title="{topten_list.VIEW_TOPIC_TITLE} ({L_IN}{L_COLON} {topten_list.VIEW_TOPIC_FORUM})">{topten_list.VIEW_TOPIC_TITLE_SHORT}</a> <span style="color: #708090">({L_POST_BY_AUTHOR} {topten_list.VIEW_TOPIC_AUTHOR})</span></dd>
+					<dd id="ttt_fifth" class="responsive-show"><a style=" font-weight: bold" href="{topten_list.LAST_POST_LINK}" title="{topten_list.LAST_POST_TITLE} ({L_IN}{L_COLON} {topten_list.LAST_POST_FORUM})">{topten_list.LAST_POST_TITLE_SHORT}</a> <span style="color: #708090">({L_POST_BY_AUTHOR} {topten_list.LAST_POST_AUTHOR})</span></dd>               
 				</dl>
 			</li>   
 		<!-- END topten_list -->


### PR DESCRIPTION
Hi @bruninoit,

- ```in:``` replaced by: ```{L_IN}{L_COLON}```,
- ```{L_TTT_BY}``` replaced by: ```{L_POST_BY_AUTHOR}```.

Other PR related, here: https://github.com/bruninoit/toptentopics/pull/2.